### PR TITLE
Create a document to track upcoming talks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # buzz
 Community Outreach and Sponsors
+
+**Links:**  
+[Upcoming AdoptOpenJDK Talks](upcoming_talks.md)

--- a/upcoming_talks.md
+++ b/upcoming_talks.md
@@ -1,0 +1,7 @@
+# Upcoming Talks
+
+- _Event:_
+- _Date:_
+- _Title:_
+- _Speakers:_
+- _Status:_


### PR DESCRIPTION
A document for listing upcoming AdoptOpenJDK talks, to allow coordination and coverage.

Prevents multiple people spending time proposing an abstract for the same conference, and also ensures important conferences are covered.